### PR TITLE
fix/send-documents-pdf

### DIFF
--- a/components/forms/proposal/fifth_step.jsx
+++ b/components/forms/proposal/fifth_step.jsx
@@ -74,9 +74,16 @@ const RequiredDocuments = ({ proposal_id, documents, setDocuments, error, setErr
             sanitizedFileName,
           );
 
-          await fetch(uploadUrlRes.URL, {
-            method: uploadUrlRes.Method,
-            headers: uploadUrlRes.SignedHeader,
+          console.log(acceptedFiles[0].type)
+          console.log(uploadUrlRes);
+
+          const result = await fetch(uploadUrlRes.URL, {
+            method: uploadUrlRes.Method, // Confirma se está vindo como PUT
+            headers: {
+              ...uploadUrlRes.SignedHeader,
+              'Content-Type': acceptedFiles[0].type, // Garante que é "application/pdf"
+            },
+            body: acceptedFiles[0], // Envia o arquivo corretamente
           }).then((res) => {
             if (!res.ok) {
               Notify.error(

--- a/components/forms/proposal/fifth_step.jsx
+++ b/components/forms/proposal/fifth_step.jsx
@@ -74,9 +74,6 @@ const RequiredDocuments = ({ proposal_id, documents, setDocuments, error, setErr
             sanitizedFileName,
           );
 
-          console.log(acceptedFiles[0].type)
-          console.log(uploadUrlRes);
-
           const result = await fetch(uploadUrlRes.URL, {
             method: uploadUrlRes.Method, // Confirma se está vindo como PUT
             headers: {

--- a/components/proposal/proposal_form.jsx
+++ b/components/proposal/proposal_form.jsx
@@ -51,10 +51,10 @@ export default function ProposalForm() {
     isProposalMenuOpen &&
       proposal?.id &&
       api.get(`/jobs/proposal/forms/${proposal?.id}`).then(({ data }) => {
-        const foundForms = data.filter((form) => form.name.startsWith('form_'));
+        const foundForms = data?.filter((form) => form.name.startsWith('form_'));
         const foundForm =
-          foundForms.length > 0
-            ? foundForms.reduce((prev, current) =>
+          foundForms?.length > 0
+            ? foundForms?.reduce((prev, current) =>
                 Number(current.name.replace('form_', '')) > Number(prev.name.replace('form_', ''))
                   ? current
                   : prev,


### PR DESCRIPTION
- Após longas análises no código, foi notado que, na hora do candidato fazer o envio da documentação por PDF, não estava sendo enviado o tipo do conteúdo, especificado o tipo de requisição e, além disso, não havia o body com o PDF, por esse motivo, os documentos estavam sendo enviados sem conteúdo.
- O ajuste foi feito das linhas 78 a 83.